### PR TITLE
Fixing the bug in Besu-node http-ingress.yaml

### DIFF
--- a/helmfile/quorum-besu/ibft2/charts/besu-node/templates/http-ingress.yaml
+++ b/helmfile/quorum-besu/ibft2/charts/besu-node/templates/http-ingress.yaml
@@ -31,5 +31,5 @@ spec:
         - path: {{ $ingressPath }}
           backend:
             serviceName: {{ $fullName }}
-            servicePort: http
+            servicePort: 8545
 {{- end }}


### PR DESCRIPTION
By having 
```
servicePort: http
```
it cannot find the Endpoint. Actual service that is proxied via ingress is exposing 8545 as http rpc port.
It should have
```
servicePort: 8545
```